### PR TITLE
fix: Update QR code generation to return Base64 data URI for better browser compatibility

### DIFF
--- a/src/main/java/br/com/lucascaldas/authguard/infrastructure/service/OneTimeTokenGeneratorService.java
+++ b/src/main/java/br/com/lucascaldas/authguard/infrastructure/service/OneTimeTokenGeneratorService.java
@@ -1,8 +1,5 @@
 package br.com.lucascaldas.authguard.infrastructure.service;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
 import java.io.IOException;
@@ -47,7 +44,10 @@ public class OneTimeTokenGeneratorService {
 
         try {
             byte[] qrCodeImage = QRCodeGenerator.getQRCodeImage(qrCodeUrl, 250, 250);
-            return Base64.getEncoder().encodeToString(qrCodeImage);
+            // Encode the image to Base64
+            String base64Image = Base64.getEncoder().encodeToString(qrCodeImage);
+            // Prepend the data URI header so browsers can render it correctly
+            return "data:image/png;base64," + base64Image;
         } catch (WriterException | IOException e) {
             log.error("Error generating QR Code image", e);
             return null;


### PR DESCRIPTION
This pull request includes changes to the `OneTimeTokenGeneratorService` to improve the generation and encoding of one-time tokens. The most important changes involve removing unused imports and updating the `generateOTT` method to ensure the generated QR code image is properly formatted for browser rendering.

Codebase simplification:

* [`src/main/java/br/com/lucascaldas/authguard/infrastructure/service/OneTimeTokenGeneratorService.java`](diffhunk://#diff-7592e68641e1d89701922689234e42f06e18835fa71e3b067bac74af5b16cae9L3-L5): Removed unused imports (`Matcher`, `Pattern`, and `SecureRandom`).

Improvements to token generation:

* [`src/main/java/br/com/lucascaldas/authguard/infrastructure/service/OneTimeTokenGeneratorService.java`](diffhunk://#diff-7592e68641e1d89701922689234e42f06e18835fa71e3b067bac74af5b16cae9L50-R50): Modified the `generateOTT` method to prepend the data URI header to the Base64 encoded QR code image, ensuring it is correctly rendered by browsers.