### PR TITLE
refactor: Simplify email token sending and update Socket.IO configuration

### DIFF
--- a/src/main/java/br/com/lucascaldas/authguard/api/controller/EmailController.java
+++ b/src/main/java/br/com/lucascaldas/authguard/api/controller/EmailController.java
@@ -26,16 +26,15 @@ public class EmailController {
     OneTimeTokenService oneTimeTokenService;
 
     @PostMapping("/send-token")
-    public ResponseEntity<OneTimeToken> sendOneTimeToken(@RequestBody EmailRequestDTO emailRequest) throws IOException {
-        OneTimeToken token = resendEmailService.sendEmailWithToken(emailRequest.getDestinatario());
-        return ResponseEntity.ok(token);
+    public ResponseEntity<Void> sendOneTimeToken(@RequestBody EmailRequestDTO emailRequest) throws IOException {
+        resendEmailService.sendEmailWithToken(emailRequest.getDestinatario());
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/validate")
-    public ResponseEntity<String> sendTimeToken(@RequestBody ValidateTokenRequestDTO dto)  {
+    public ResponseEntity<String> sendTimeToken(@RequestBody ValidateTokenRequestDTO dto) {
         resendEmailService.validateToken(dto.getToken());
         return ResponseEntity.ok("One-Time Token generated and sent via email.");
     }
-
 
 }

--- a/src/main/java/br/com/lucascaldas/authguard/core/config/SocketIOConfig.java
+++ b/src/main/java/br/com/lucascaldas/authguard/core/config/SocketIOConfig.java
@@ -17,6 +17,7 @@ public class SocketIOConfig {
     @Bean
     public SocketIOServer socketIOServer() {
         Configuration config = new Configuration();
+        config.setHostname("localhost");
         config.setPort(port);
         // Optionally, set additional configuration (e.g., authorization, ping timeout, etc.)
         return new SocketIOServer(config);

--- a/src/main/java/br/com/lucascaldas/authguard/infrastructure/service/EmailService.java
+++ b/src/main/java/br/com/lucascaldas/authguard/infrastructure/service/EmailService.java
@@ -1,8 +1,6 @@
 package br.com.lucascaldas.authguard.infrastructure.service;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +9,10 @@ import org.springframework.security.authentication.ott.OneTimeToken;
 import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
 import org.springframework.security.authentication.ott.OneTimeTokenService;
 import org.springframework.stereotype.Service;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+import java.nio.charset.StandardCharsets;
 
 import com.resend.Resend;
 import com.resend.core.exception.ResendException;
@@ -31,32 +33,27 @@ public class EmailService {
 
     @Autowired
     private OneTimeTokenService oneTimeTokenService;
-    
-    @Autowired
-    private OneTimeTokenAuthenticationToken auth_token;
 
-    private static final String TEMPLATE_PATH = "src/main/resources/templates/shopsession-regular.html";
+    private static final String TEMPLATE_CLASSPATH = "templates/shopsession-regular.html";
 
-    public OneTimeToken sendEmailWithToken(String to) throws IOException {
+    public Void sendEmailWithToken(String to) throws IOException {
         GenerateOneTimeTokenRequest request = new GenerateOneTimeTokenRequest(to);
         OneTimeToken token = oneTimeTokenService.generate(request);
 
-        OneTimeTokenAuthenticationToken tokenAuth = new OneTimeTokenAuthenticationToken(token.getTokenValue());
-        OneTimeToken tokenResult = oneTimeTokenService.consume(tokenAuth);
-
-        log.info(tokenResult.toString());
+        log.info(token.toString());
 
         sendEmail(to, token.getTokenValue());
 
-        return token;
-
+        return null;
     }
 
     public void sendEmail(String to, String token) throws IOException {
-
         Resend resend = new Resend(apiKey);
 
-        String htmlTemplate = new String(Files.readAllBytes(Paths.get(TEMPLATE_PATH)), "UTF-8");
+        // Load the HTML template from the classpath
+        Resource resource = new ClassPathResource(TEMPLATE_CLASSPATH);
+        String htmlTemplate = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+
         String tokenLink = baseUrl + "?token=" + token;
         String htmlContent = htmlTemplate.replace("{{validation_token}}", tokenLink);
 

--- a/src/main/java/br/com/lucascaldas/authguard/infrastructure/utils/SocketIOEventHandler.java
+++ b/src/main/java/br/com/lucascaldas/authguard/infrastructure/utils/SocketIOEventHandler.java
@@ -32,5 +32,17 @@ public class SocketIOEventHandler {
             log.info("Socket " + socket.getSessionId() + " joined room: " + roomId);
         });
 
+        // Listen for an "authenticate" event from the client
+        server.addEventListener("authenticate", String.class, (socket, email, ackSender) -> {
+            
+        });
+
+        // Listen for a "sendMessage" event from the client
+        server.addEventListener("sendMessage", String.class, (socket, message, ackSender) -> {
+            String roomId = socket.getAllRooms().iterator().next(); // Assuming the socket is in one room
+            server.getRoomOperations(roomId).sendEvent("message", message);
+            log.info("Socket " + socket.getSessionId() + " sent message to room " + roomId + ": " + message);
+        });
     }
+
 }


### PR DESCRIPTION
This pull request includes several changes to the `EmailController`, `EmailService`, `SocketIOConfig`, and `SocketIOEventHandler` classes to improve functionality and code maintainability. The most important changes include modifying the `sendOneTimeToken` method to return `Void`, updating the email template loading mechanism, and adding event listeners for socket events.

### EmailController changes:
* Modified the `sendOneTimeToken` method to return `Void` instead of `OneTimeToken` and updated the response to `ResponseEntity<Void>`.

### EmailService changes:
* Changed the method signature of `sendEmailWithToken` to return `Void` instead of `OneTimeToken`.
* Updated the email template loading mechanism to read from the classpath using `Resource` and `StreamUtils` instead of file paths.

### SocketIOConfig changes:
* Set the hostname to "localhost" in the `socketIOServer` bean configuration.

### SocketIOEventHandler changes:
* Added event listeners for "authenticate" and "sendMessage" events to handle client interactions.